### PR TITLE
[DO NOT MERGE] try setting the content of the node

### DIFF
--- a/main.go
+++ b/main.go
@@ -67,6 +67,9 @@ func fillTable(table xml.Node) (err error) {
 	if err != nil {
 		return
 	}
+
+	printNode(roleCell)
+	roleCell.SetContent("foo")
 	printNode(roleCell)
 
 	return


### PR DESCRIPTION
@jcscottiii Running into a problem here...not sure if it's just my limited understanding of how to use pointers? Looking at [this blog post](https://medium.com/@cristianvg/editing-xml-files-with-gokogiri-8839c0b5f6f9#.bol9dokcj), it _seems_ like I'm doing the right thing... Ideas?

```
$ ./fedramp-templater fixtures/FedRAMP_ac-2-1_v2.1.docx tmp/output.docx
2016/05/27 10:18:09 Read File `fixtures/FedRAMP_ac-2-1_v2.1.docx`
&xml.ElementNode{XmlNode:(*xml.XmlNode)(0xc82007a8e0)} "Responsible Role:"
panic: runtime error: cgo argument has Go pointer to Go pointer

goroutine 1 [running]:
panic(0x41ab9e0, 0xc820062630)
    /usr/local/Cellar/go/1.6.2/libexec/src/runtime/panic.go:481 +0x3e6
github.com/opencontrol/fedramp-templater/vendor/github.com/moovweb/gokogiri/xml._cgoCheckPointer0(0x4156b80, 0xc82007a8e0, 0x0, 0x0, 0x0, 0x0)
    ??:0 +0x4d
github.com/opencontrol/fedramp-templater/vendor/github.com/moovweb/gokogiri/xml.(*XmlNode).SetContent(0xc82007a8e0, 0x414e0e0, 0xc82007a920, 0x0, 0x0)
    /Users/aidanfeldman/dev/go/src/github.com/opencontrol/fedramp-templater/vendor/github.com/moovweb/gokogiri/xml/node.go:406 +0x278
github.com/opencontrol/fedramp-templater/vendor/github.com/moovweb/gokogiri/xml.(*XmlNode).SetContent(0xc82007a8e0, 0x4156780, 0xc820062610, 0x0, 0x0)
    /Users/aidanfeldman/dev/go/src/github.com/opencontrol/fedramp-templater/vendor/github.com/moovweb/gokogiri/xml/node.go:402 +0x47c
main.fillTable(0x47846e8, 0xc820078040, 0x0, 0x0)
    /Users/aidanfeldman/dev/go/src/github.com/opencontrol/fedramp-templater/main.go:72 +0xe5
main.templatizeXMLDoc(0xc8200953b0, 0x0, 0x0)
    /Users/aidanfeldman/dev/go/src/github.com/opencontrol/fedramp-templater/main.go:84 +0xef
main.main()
    /Users/aidanfeldman/dev/go/src/github.com/opencontrol/fedramp-templater/main.go:104 +0x1c2
```

https://godoc.org/github.com/moovweb/gokogiri/xml#XmlNode.SetContent
