### PR TITLE
improve installation instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,17 +20,20 @@ with this waiver of copyright interest.
 
 ## Development
 
-Requires [Go](https://golang.org/) 1.6+.
-
-1. Clone the repository.
+1. Follow the [installation instructions](README.md#installation).
+1. Go to the repository directory.
 
     ```bash
-    git clone https://github.com/opencontrol/fedramp-templater
-    cd fedramp-templater
+    cd $GOPATH/src/github.com/opencontrol/fedramp-templater
     ```
 
-1. [Install `gokogiri` dependencies.](https://github.com/moovweb/gokogiri/pull/95/files)
 1. _code code code_
+1. Run the tests.
+
+    ```bash
+    go test -v $(go list ./... | grep -v /vendor/)
+    ```
+
 1. Run the CLI.
 
     ```bash

--- a/README.md
+++ b/README.md
@@ -2,15 +2,18 @@
 
 This is a command-line tool to take the [FedRAMP](http://www.fedramp.gov/) System Security Plan template and transform it to be [Compliance Masonry](https://github.com/opencontrol/compliance-masonry)-compatible.
 
-## Usage
+## Installation
 
 Requires [Go](https://golang.org/) 1.6+.
 
+1. [Install `gokogiri` dependencies.](https://github.com/moovweb/gokogiri/pull/95/files)
 1. Install the tool:
 
     ```bash
     go get github.com/opencontrol/fedramp-templater
     ```
+
+## Usage
 
 1. [Download the `System Security Plan (SSP)` template.](https://www.fedramp.gov/resources/templates-2016/) (Tested with [v2.1](https://www.fedramp.gov/files/2015/03/FedRAMP-System-Security-Plan-Template-v2.1.docx).)
 1. Run


### PR DESCRIPTION
Takes general installation instructions and moves them from CONTRIBUTING to the README. Also adds information about running the tests.
