### PR TITLE
create a package for fixture helpers

### DIFF
--- a/control/narrative_section.go
+++ b/control/narrative_section.go
@@ -5,8 +5,9 @@ import (
 	"regexp"
 
 	"github.com/jbowtie/gokogiri/xml"
-	"github.com/opencontrol/fedramp-templater/docx/helper"
+	docxHelper "github.com/opencontrol/fedramp-templater/docx/helper"
 	"github.com/opencontrol/fedramp-templater/opencontrols"
+	xmlHelper "github.com/opencontrol/fedramp-templater/xml/helper"
 )
 
 type narrativeSection struct {
@@ -27,7 +28,7 @@ func (n narrativeSection) parsePart() (key string, err error) {
 
 // GetKey returns the narrative section "part"/key. `key` will be an empty string if there is no "Part".
 func (n narrativeSection) GetKey() (key string, err error) {
-	cells, err := n.row.Search(`./w:tc`)
+	cells, err := xmlHelper.SearchSubtree(n.row, `./w:tc`)
 	numCells := len(cells)
 	if numCells == 1 {
 		// there is only a single narrative section
@@ -47,11 +48,10 @@ func (n narrativeSection) GetKey() (key string, err error) {
 // Fill populates the section/part with the narrative for this control part from the provided data.
 func (n narrativeSection) Fill(data opencontrols.Data, control string) (err error) {
 	// the row should have one or two cells; either way, the last one is what should be filled
-	cellNodes, err := n.row.Search(`./w:tc[last()]`)
+	cellNode, err := xmlHelper.SearchOne(n.row, `./w:tc[last()]`)
 	if err != nil {
 		return
 	}
-	cellNode := cellNodes[0]
 
 	key, err := n.GetKey()
 	if err != nil {
@@ -59,7 +59,7 @@ func (n narrativeSection) Fill(data opencontrols.Data, control string) (err erro
 	}
 
 	narrative := data.GetNarrative(control, key)
-	helper.FillCell(cellNode, narrative)
+	docxHelper.FillCell(cellNode, narrative)
 
 	return
 }

--- a/control/narrative_section.go
+++ b/control/narrative_section.go
@@ -1,0 +1,65 @@
+package control
+
+import (
+	"errors"
+	"regexp"
+
+	"github.com/jbowtie/gokogiri/xml"
+	"github.com/opencontrol/fedramp-templater/docx/helper"
+	"github.com/opencontrol/fedramp-templater/opencontrols"
+)
+
+type narrativeSection struct {
+	row xml.Node
+}
+
+func (n narrativeSection) parsePart() (key string, err error) {
+	re := regexp.MustCompile(`Part ([a-z])`)
+	content := []byte(n.row.Content())
+	subMatches := re.FindSubmatch(content)
+	if len(subMatches) != 2 {
+		err = errors.New("No Parts found.")
+		return
+	}
+	key = string(subMatches[1])
+	return
+}
+
+// GetKey returns the narrative section "part"/key. `key` will be an empty string if there is no "Part".
+func (n narrativeSection) GetKey() (key string, err error) {
+	cells, err := n.row.Search(`./w:tc`)
+	numCells := len(cells)
+	if numCells == 1 {
+		// there is only a single narrative section
+		key = ""
+	} else if numCells == 2 {
+		key, err = n.parsePart()
+		if err != nil {
+			return
+		}
+	} else {
+		err = errors.New("Don't know how to parse row.")
+	}
+
+	return
+}
+
+// Fill populates the section/part with the narrative for this control part from the provided data.
+func (n narrativeSection) Fill(data opencontrols.Data, control string) (err error) {
+	// the row should have one or two cells; either way, the last one is what should be filled
+	cellNodes, err := n.row.Search(`./w:tc[last()]`)
+	if err != nil {
+		return
+	}
+	cellNode := cellNodes[0]
+
+	key, err := n.GetKey()
+	if err != nil {
+		return
+	}
+
+	narrative := data.GetNarrative(control, key)
+	helper.FillCell(cellNode, narrative)
+
+	return
+}

--- a/control/narrative_table.go
+++ b/control/narrative_table.go
@@ -5,6 +5,13 @@ import (
 	"github.com/opencontrol/fedramp-templater/opencontrols"
 )
 
+func fillRow(row xml.Node, data opencontrols.Data, control string, section string) {
+	// equivalent XPath: `./w:tc[last()]/w:p[1]`
+	textField := row.LastChild().FirstChild()
+	narrative := data.GetNarrative(control, section)
+	textField.SetContent(narrative)
+}
+
 type NarrativeTable struct {
 	tbl table
 }
@@ -33,28 +40,13 @@ func (t *NarrativeTable) Fill(openControlData opencontrols.Data) (err error) {
 	if len(rows) == 1 {
 		// singular narrative
 		row := rows[0]
-		textFields, err := row.Search(`(./w:tc/w:p)[1]`)
-		if err != nil {
-			return err
-		}
-		textField := textFields[0]
-
-		narrative := openControlData.GetNarrative(control, "")
-		textField.SetContent(narrative)
+		fillRow(row, openControlData, control, "")
 	} else {
 		// multiple parts
 		for _, row := range rows {
 			// TODO remove hard-coding
 			sectionKey := "b"
-
-			textFields, err := row.Search(`./w:tc[position() = 1]/w:p`)
-			if err != nil {
-				return err
-			}
-			textField := textFields[0]
-
-			narrative := openControlData.GetNarrative(control, sectionKey)
-			textField.SetContent(narrative)
+			fillRow(row, openControlData, control, sectionKey)
 		}
 	}
 

--- a/control/narrative_table.go
+++ b/control/narrative_table.go
@@ -1,0 +1,38 @@
+package control
+
+import (
+	"fmt"
+
+	"github.com/jbowtie/gokogiri/xml"
+	"github.com/opencontrol/fedramp-templater/opencontrols"
+)
+
+type NarrativeTable struct {
+	tbl table
+}
+
+func NewNarrativeTable(root xml.Node) NarrativeTable {
+	tbl := table{Root: root}
+	return NarrativeTable{tbl}
+}
+
+func (t *NarrativeTable) SectionRows() ([]xml.Node, error) {
+	// skip the header row
+	return t.tbl.searchSubtree(`.//w:tr[position() > 1]`)
+}
+
+func (t *NarrativeTable) Fill(openControlData opencontrols.Data) (err error) {
+	control, err := t.tbl.controlName()
+	if err != nil {
+		return
+	}
+	// TODO remove hard-coding
+	sectionKey := "b"
+
+	narrative := openControlData.GetNarrative(control, sectionKey)
+	fmt.Println(narrative)
+
+	// TODO fill it in
+
+	return
+}

--- a/control/narrative_table.go
+++ b/control/narrative_table.go
@@ -1,8 +1,6 @@
 package control
 
 import (
-	"fmt"
-
 	"github.com/jbowtie/gokogiri/xml"
 	"github.com/opencontrol/fedramp-templater/opencontrols"
 )
@@ -26,13 +24,39 @@ func (t *NarrativeTable) Fill(openControlData opencontrols.Data) (err error) {
 	if err != nil {
 		return
 	}
-	// TODO remove hard-coding
-	sectionKey := "b"
 
-	narrative := openControlData.GetNarrative(control, sectionKey)
-	fmt.Println(narrative)
+	rows, err := t.SectionRows()
+	if err != nil {
+		return
+	}
 
-	// TODO fill it in
+	if len(rows) == 1 {
+		// singular narrative
+		row := rows[0]
+		textFields, err := row.Search(`(./w:tc/w:p)[1]`)
+		if err != nil {
+			return err
+		}
+		textField := textFields[0]
+
+		narrative := openControlData.GetNarrative(control, "")
+		textField.SetContent(narrative)
+	} else {
+		// multiple parts
+		for _, row := range rows {
+			// TODO remove hard-coding
+			sectionKey := "b"
+
+			textFields, err := row.Search(`./w:tc[position() = 1]/w:p`)
+			if err != nil {
+				return err
+			}
+			textField := textFields[0]
+
+			narrative := openControlData.GetNarrative(control, sectionKey)
+			textField.SetContent(narrative)
+		}
+	}
 
 	return
 }

--- a/control/narrative_table.go
+++ b/control/narrative_table.go
@@ -49,20 +49,24 @@ func fillRows(rows []xml.Node, data opencontrols.Data, control string) error {
 	return nil
 }
 
+// NarrativeTable represents the node in the Word docx XML tree that corresponds to the justification fields for a security control.
 type NarrativeTable struct {
 	tbl table
 }
 
+// NewNarrativeTable creates a NarrativeTable instance.
 func NewNarrativeTable(root xml.Node) NarrativeTable {
 	tbl := table{Root: root}
 	return NarrativeTable{tbl}
 }
 
+// SectionRows returns the list of rows which correspond to each "part" of the narrative. Will return a single row when the narrative isn't split into parts.
 func (t *NarrativeTable) SectionRows() ([]xml.Node, error) {
 	// skip the header row
 	return t.tbl.searchSubtree(`.//w:tr[position() > 1]`)
 }
 
+// Fill inserts the OpenControl data into the table.
 func (t *NarrativeTable) Fill(openControlData opencontrols.Data) (err error) {
 	control, err := t.tbl.controlName()
 	if err != nil {

--- a/control/narrative_table.go
+++ b/control/narrative_table.go
@@ -22,14 +22,14 @@ func findSectionKey(row xml.Node) (section string, err error) {
 
 func fillRow(row xml.Node, data opencontrols.Data, control string, section string) (err error) {
 	// the row should have one or two cells; either way, the last one is what should be filled
-	paragraphNodes, err := row.Search(`./w:tc[last()]/w:p[1]`)
+	cellNodes, err := row.Search(`./w:tc[last()]`)
 	if err != nil {
 		return
 	}
-	paragraphNode := paragraphNodes[0]
+	cellNode := cellNodes[0]
 
 	narrative := data.GetNarrative(control, section)
-	helper.FillParagraph(paragraphNode, narrative)
+	helper.FillCell(cellNode, narrative)
 
 	return
 }

--- a/control/narrative_table.go
+++ b/control/narrative_table.go
@@ -51,7 +51,7 @@ func fillRows(rows []xml.Node, data opencontrols.Data, control string) error {
 
 // NarrativeTable represents the node in the Word docx XML tree that corresponds to the justification fields for a security control.
 type NarrativeTable struct {
-	tbl table
+	table
 }
 
 // NewNarrativeTable creates a NarrativeTable instance.
@@ -63,12 +63,12 @@ func NewNarrativeTable(root xml.Node) NarrativeTable {
 // SectionRows returns the list of rows which correspond to each "part" of the narrative. Will return a single row when the narrative isn't split into parts.
 func (t *NarrativeTable) SectionRows() ([]xml.Node, error) {
 	// skip the header row
-	return t.tbl.searchSubtree(`.//w:tr[position() > 1]`)
+	return t.table.searchSubtree(`.//w:tr[position() > 1]`)
 }
 
 // Fill inserts the OpenControl data into the table.
 func (t *NarrativeTable) Fill(openControlData opencontrols.Data) (err error) {
-	control, err := t.tbl.controlName()
+	control, err := t.table.controlName()
 	if err != nil {
 		return
 	}

--- a/control/narrative_table_test.go
+++ b/control/narrative_table_test.go
@@ -1,0 +1,37 @@
+package control_test
+
+import (
+	. "github.com/opencontrol/fedramp-templater/control"
+	"github.com/opencontrol/fedramp-templater/fixtures"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("NarrativeTable", func() {
+	Describe("SectionRows", func() {
+		It("returns the correct number for a singular narrative", func() {
+			doc := fixtures.LoadSSP("FedRAMP_ac-2-1_v2.1.docx")
+			defer doc.Close()
+			root, err := doc.NarrativeTable("AC-2 (1)")
+			Expect(err).NotTo(HaveOccurred())
+
+			table := NewNarrativeTable(root)
+			sections, err := table.SectionRows()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(sections)).To(Equal(1))
+		})
+
+		It("returns the correct number for multiple narrative sections", func() {
+			doc := fixtures.LoadSSP("FedRAMP_ac-2_v2.1.docx")
+			defer doc.Close()
+			root, err := doc.NarrativeTable("AC-2")
+			Expect(err).NotTo(HaveOccurred())
+
+			table := NewNarrativeTable(root)
+			sections, err := table.SectionRows()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(sections)).To(Equal(11))
+		})
+	})
+})

--- a/control/responsible_role.go
+++ b/control/responsible_role.go
@@ -10,8 +10,8 @@ import (
 )
 
 // findResponsibleRole looks for the Responsible Role cell in the control table.
-func findResponsibleRole(st *SummaryTable) (*responsibleRole, error) {
-	nodes, err := st.tbl.searchSubtree(".//w:tc[starts-with(normalize-space(.), 'Responsible Role')]")
+func findResponsibleRole(ct *SummaryTable) (*responsibleRole, error) {
+	nodes, err := ct.table.searchSubtree(".//w:tc[starts-with(normalize-space(.), 'Responsible Role')]")
 	if err != nil {
 		return nil, err
 	}

--- a/control/responsible_role.go
+++ b/control/responsible_role.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/jbowtie/gokogiri/xml"
+	"github.com/opencontrol/fedramp-templater/xml/helper"
 )
 
 // findResponsibleRole looks for the Responsible Role cell in the control table.
@@ -19,7 +20,7 @@ func findResponsibleRole(ct *SummaryTable) (*responsibleRole, error) {
 		return nil, errors.New("could not find Responsible Role cell")
 	}
 	parentNode := nodes[0]
-	childNodes, err := parentNode.Search(".//w:t")
+	childNodes, err := helper.SearchSubtree(parentNode, `.//w:t`)
 	if err != nil || len(childNodes) < 1 {
 		return nil, errors.New("Should not happen, cannot find text nodes.")
 	}

--- a/control/responsible_role.go
+++ b/control/responsible_role.go
@@ -11,7 +11,7 @@ import (
 
 // findResponsibleRole looks for the Responsible Role cell in the control table.
 func findResponsibleRole(st *SummaryTable) (*responsibleRole, error) {
-	nodes, err := st.searchSubtree(".//w:tc[starts-with(normalize-space(.), 'Responsible Role')]")
+	nodes, err := st.tbl.searchSubtree(".//w:tc[starts-with(normalize-space(.), 'Responsible Role')]")
 	if err != nil {
 		return nil, err
 	}

--- a/control/summary_table.go
+++ b/control/summary_table.go
@@ -10,11 +10,12 @@ const (
 	responsibleRoleField = "Responsible Role"
 )
 
-// SummaryTable represents the node in the Word docx XML tree that corresponds to a security control.
+// SummaryTable represents the node in the Word docx XML tree that corresponds to the summary information for a security control.
 type SummaryTable struct {
 	tbl table
 }
 
+// NewSummaryTable creates a SummaryTable instance.
 func NewSummaryTable(root xml.Node) SummaryTable {
 	tbl := table{Root: root}
 	return SummaryTable{tbl}

--- a/control/summary_table.go
+++ b/control/summary_table.go
@@ -5,7 +5,6 @@ import (
 	"regexp"
 	"strings"
 
-	// using fork because of https://github.com/moovweb/gokogiri/pull/93#issuecomment-215582446
 	"github.com/jbowtie/gokogiri/xml"
 	"github.com/opencontrol/fedramp-templater/opencontrols"
 	"github.com/opencontrol/fedramp-templater/reporter"

--- a/control/summary_table.go
+++ b/control/summary_table.go
@@ -12,7 +12,7 @@ const (
 
 // SummaryTable represents the node in the Word docx XML tree that corresponds to the summary information for a security control.
 type SummaryTable struct {
-	tbl table
+	table
 }
 
 // NewSummaryTable creates a SummaryTable instance.
@@ -22,7 +22,7 @@ func NewSummaryTable(root xml.Node) SummaryTable {
 }
 
 func (st *SummaryTable) controlName() (name string, err error) {
-	return st.tbl.controlName()
+	return st.table.controlName()
 }
 
 // Fill inserts the OpenControl justifications into the table. Note this modifies the `table`.

--- a/control/summary_table_test.go
+++ b/control/summary_table_test.go
@@ -46,7 +46,7 @@ var _ = Describe("SummaryTable", func() {
 	Describe("Fill", func() {
 		It("fills in the Responsible Role for controls", func() {
 			table := getTable("AC-2")
-			st := SummaryTable{Root: table}
+			st := NewSummaryTable(table)
 			openControlData := fixtures.LoadOpenControlFixture()
 
 			st.Fill(openControlData)
@@ -56,7 +56,7 @@ var _ = Describe("SummaryTable", func() {
 
 		It("fills in the Responsible Role for control enhancements", func() {
 			table := getTable("AC-2 (1)")
-			st := SummaryTable{Root: table}
+			st := NewSummaryTable(table)
 			openControlData := fixtures.LoadOpenControlFixture()
 
 			st.Fill(openControlData)
@@ -68,7 +68,7 @@ var _ = Describe("SummaryTable", func() {
 	Describe("Diff", func() {
 		It("detects no diff when the value of responsible role is empty", func() {
 			table := getTable("AC-2")
-			st := SummaryTable{Root: table}
+			st := NewSummaryTable(table)
 			openControlData := fixtures.LoadOpenControlFixture()
 			diff, err := st.Diff(openControlData)
 

--- a/control/summary_table_test.go
+++ b/control/summary_table_test.go
@@ -5,9 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"text/template"
-	// using fork because of https://github.com/moovweb/gokogiri/pull/93#issuecomment-215582446
-	"github.com/jbowtie/gokogiri/xml"
 
+	"github.com/jbowtie/gokogiri/xml"
 	. "github.com/opencontrol/fedramp-templater/control"
 	"github.com/opencontrol/fedramp-templater/docx/helper"
 	"github.com/opencontrol/fedramp-templater/opencontrols"

--- a/control/summary_table_test.go
+++ b/control/summary_table_test.go
@@ -2,15 +2,13 @@ package control_test
 
 import (
 	"bytes"
-	"os"
-	"path/filepath"
 	"text/template"
 
 	"github.com/jbowtie/gokogiri/xml"
 	. "github.com/opencontrol/fedramp-templater/control"
 	"github.com/opencontrol/fedramp-templater/docx/helper"
-	"github.com/opencontrol/fedramp-templater/opencontrols"
 	"github.com/opencontrol/fedramp-templater/ssp"
+	"github.com/opencontrol/fedramp-templater/fixtures"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -22,7 +20,7 @@ type tableData struct {
 }
 
 func docFixture(control string) *xml.XmlDocument {
-	path := filepath.Join("..", "fixtures", "simplified_table.xml")
+	path := fixtures.FixturePath("simplified_table.xml")
 	tpl, err := template.ParseFiles(path)
 	Expect(err).ToNot(HaveOccurred())
 
@@ -44,32 +42,12 @@ func getTable(control string) xml.Node {
 	return tables[0]
 }
 
-func openControlFixturePath() string {
-	path := filepath.Join("..", "fixtures", "opencontrols")
-	path, err := filepath.Abs(path)
-	Expect(err).NotTo(HaveOccurred())
-	_, err = os.Stat(path)
-	Expect(err).NotTo(HaveOccurred())
-
-	return path
-}
-
-func openControlFixture() opencontrols.Data {
-	path := openControlFixturePath()
-	data, errors := opencontrols.LoadFrom(path)
-	for _, err := range errors {
-		Expect(err).NotTo(HaveOccurred())
-	}
-
-	return data
-}
-
 var _ = Describe("SummaryTable", func() {
 	Describe("Fill", func() {
 		It("fills in the Responsible Role for controls", func() {
 			table := getTable("AC-2")
 			st := SummaryTable{Root: table}
-			openControlData := openControlFixture()
+			openControlData := fixtures.LoadOpenControlFixture()
 
 			st.Fill(openControlData)
 
@@ -79,7 +57,7 @@ var _ = Describe("SummaryTable", func() {
 		It("fills in the Responsible Role for control enhancements", func() {
 			table := getTable("AC-2 (1)")
 			st := SummaryTable{Root: table}
-			openControlData := openControlFixture()
+			openControlData := fixtures.LoadOpenControlFixture()
 
 			st.Fill(openControlData)
 
@@ -91,8 +69,7 @@ var _ = Describe("SummaryTable", func() {
 		It("detects no diff when the value of responsible role is empty", func() {
 			table := getTable("AC-2")
 			st := SummaryTable{Root: table}
-			openControlData := openControlFixture()
-
+			openControlData := fixtures.LoadOpenControlFixture()
 			diff, err := st.Diff(openControlData)
 
 			Expect(diff).To(Equal([]reporter.Reporter{}))

--- a/control/table.go
+++ b/control/table.go
@@ -3,23 +3,17 @@ package control
 import (
 	"errors"
 	"regexp"
-	"strings"
 
 	"github.com/jbowtie/gokogiri/xml"
+	"github.com/opencontrol/fedramp-templater/xml/helper"
 )
 
 type table struct {
 	Root xml.Node
 }
 
-func (t *table) searchSubtree(xpath string) (nodes []xml.Node, err error) {
-	// http://stackoverflow.com/a/25387687/358804
-	if !strings.HasPrefix(xpath, ".") {
-		err = errors.New("XPath must have leading period (`.`) to only search the subtree")
-		return
-	}
-
-	return t.Root.Search(xpath)
+func (t *table) searchSubtree(xpath string) ([]xml.Node, error) {
+	return helper.SearchSubtree(t.Root, xpath)
 }
 
 func (t *table) tableHeader() (content string, err error) {

--- a/control/table.go
+++ b/control/table.go
@@ -1,0 +1,53 @@
+package control
+
+import (
+	"errors"
+	"regexp"
+	"strings"
+
+	"github.com/jbowtie/gokogiri/xml"
+)
+
+type table struct {
+	Root xml.Node
+}
+
+func (t *table) searchSubtree(xpath string) (nodes []xml.Node, err error) {
+	// http://stackoverflow.com/a/25387687/358804
+	if !strings.HasPrefix(xpath, ".") {
+		err = errors.New("XPath must have leading period (`.`) to only search the subtree")
+		return
+	}
+
+	return t.Root.Search(xpath)
+}
+
+func (t *table) tableHeader() (content string, err error) {
+	nodes, err := t.searchSubtree(".//w:tr")
+	if err != nil {
+		return
+	}
+	if len(nodes) == 0 {
+		err = errors.New("could not find control name")
+		return
+	}
+	// we only care about the first match
+	content = nodes[0].Content()
+
+	return
+}
+
+func (t *table) controlName() (name string, err error) {
+	content, err := t.tableHeader()
+	if err != nil {
+		return
+	}
+
+	// matches controls and control enhancements, e.g. `AC-2`, `AC-2 (1)`, etc.
+	regex := regexp.MustCompile(`[A-Z]{2}-\d+( +\(\d+\))?`)
+	name = regex.FindString(content)
+	if name == "" {
+		err = errors.New("control name not found")
+	}
+	return
+}

--- a/docx/helper/helper.go
+++ b/docx/helper/helper.go
@@ -25,3 +25,15 @@ func GenerateXML(wordDoc *docx.Docx) (xmlDoc *xml.XmlDocument, err error) {
 	bytes := []byte(content)
 	return ParseXML(bytes)
 }
+
+func FillParagraph(paragraph xml.Node, content string) (err error) {
+	// this seems to be the easiest way to create child notes
+	err = paragraph.SetChildren(`<w:r><w:t></w:t></w:r>`)
+	if err != nil {
+		return
+	}
+	textCell := paragraph.FirstChild().FirstChild()
+
+	textCell.SetContent(content)
+	return
+}

--- a/docx/helper/helper.go
+++ b/docx/helper/helper.go
@@ -26,6 +26,7 @@ func GenerateXML(wordDoc *docx.Docx) (xmlDoc *xml.XmlDocument, err error) {
 	return ParseXML(bytes)
 }
 
+// FillParagraph inserts the given content into the provided docx XML paragraph node.
 func FillParagraph(paragraph xml.Node, content string) (err error) {
 	// this seems to be the easiest way to create child notes
 	err = paragraph.SetChildren(`<w:r><w:t></w:t></w:r>`)

--- a/docx/helper/helper.go
+++ b/docx/helper/helper.go
@@ -1,7 +1,6 @@
 package helper
 
 import (
-	// using fork because of https://github.com/moovweb/gokogiri/pull/93#issuecomment-215582446
 	"github.com/jbowtie/gokogiri"
 	"github.com/jbowtie/gokogiri/xml"
 	"github.com/opencontrol/doc-template/docx"

--- a/fixtures/fixtures.go
+++ b/fixtures/fixtures.go
@@ -1,0 +1,43 @@
+package fixtures
+
+import (
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/gomega"
+	"github.com/opencontrol/fedramp-templater/opencontrols"
+	"github.com/opencontrol/fedramp-templater/ssp"
+)
+
+func FixturePath(name string) string {
+	path := filepath.Join("..", "fixtures", name)
+	path, err := filepath.Abs(path)
+	Expect(err).NotTo(HaveOccurred())
+	// ensure the file/directory exists
+	_, err = os.Stat(path)
+	Expect(err).NotTo(HaveOccurred())
+
+	return path
+}
+
+func OpenControlFixturePath() string {
+	return FixturePath("opencontrols")
+}
+
+func LoadSSP(name string) *ssp.Document {
+	sspPath := FixturePath(name)
+	doc, err := ssp.Load(sspPath)
+	Expect(err).NotTo(HaveOccurred())
+
+	return doc
+}
+
+func LoadOpenControlFixture() opencontrols.Data {
+	openControlDir := OpenControlFixturePath()
+	openControlData, errors := opencontrols.LoadFrom(openControlDir)
+	for _, err := range errors {
+		Expect(err).NotTo(HaveOccurred())
+	}
+
+	return openControlData
+}

--- a/fixtures/opencontrols/components/EC2/component.yaml
+++ b/fixtures/opencontrols/components/EC2/component.yaml
@@ -14,7 +14,10 @@ satisfies:
   implementation_status: partial
   control_origin: shared
   narrative:
-    - text: "Justification in narrative form for AC-2"
+  - key: "a"
+    text: "Justification in narrative form A for AC-2"
+  - key: "b"
+    text: "Justification in narrative form B for AC-2"
   standard_key: NIST-800-53
 - control_key: AC-2 (1)
   covered_by:
@@ -25,10 +28,7 @@ satisfies:
   implementation_status: partial
   control_origin: shared
   narrative:
-    - key: "a"
-      text: "Justification in narrative form A for AC-2 (1)"
-    - key: "b"
-      text: "Justification in narrative form B for AC-2 (1)"
+  - text: "Justification in narrative form for AC-2 (1)"
   standard_key: NIST-800-53
 responsible_role: "AWS Staff"
 schema_version: 3.0.0

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,5 +1,6 @@
 package: github.com/opencontrol/fedramp-templater
 import:
+# using fork because of https://github.com/moovweb/gokogiri/pull/93#issuecomment-215582446
 - package: github.com/jbowtie/gokogiri
   version: 94c317865760e3580e90e49c08ca54953ef1b7cb
   subpackages:

--- a/opencontrols/data.go
+++ b/opencontrols/data.go
@@ -5,14 +5,16 @@ import (
 	"github.com/opencontrol/compliance-masonry/models"
 )
 
+const standardKey = "NIST-800-53"
+
 // Data contains the OpenControl justification information.
 type Data struct {
 	ocd docx.OpenControlDocx
 }
 
 // LoadFrom creates a new Data struct from the provided path to an `opencontrols/` directory.
-func LoadFrom(path string) (data Data, errors []error) {
-	openControlData, errors := models.LoadData(path, "")
+func LoadFrom(dirPath string) (data Data, errors []error) {
+	openControlData, errors := models.LoadData(dirPath, "")
 	if len(errors) > 0 {
 		return
 	}
@@ -24,5 +26,10 @@ func LoadFrom(path string) (data Data, errors []error) {
 
 // GetResponsibleRoles returns the responsible role information for each component matching the specified control.
 func (d *Data) GetResponsibleRoles(control string) string {
-	return d.ocd.FormatResponsibleRoles("NIST-800-53", control)
+	return d.ocd.FormatResponsibleRoles(standardKey, control)
+}
+
+// GetNarrative returns the justification text for the specified control. Pass an empty string for `sectionKey` if you are looking for the overall narrative.
+func (d *Data) GetNarrative(control string, sectionKey string) string {
+	return d.ocd.FormatNarrative(standardKey, control, sectionKey)
 }

--- a/opencontrols/data_test.go
+++ b/opencontrols/data_test.go
@@ -1,37 +1,22 @@
 package opencontrols_test
 
 import (
-	"path/filepath"
-
-	. "github.com/opencontrol/fedramp-templater/opencontrols"
+	"github.com/opencontrol/fedramp-templater/fixtures"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
-// TODO share with templater_test
-func loadOpenControlFixture() Data {
-	openControlDir := filepath.Join("..", "fixtures", "opencontrols")
-	openControlDir, err := filepath.Abs(openControlDir)
-	Expect(err).NotTo(HaveOccurred())
-	openControlData, errors := LoadFrom(openControlDir)
-	for _, err := range errors {
-		Expect(err).NotTo(HaveOccurred())
-	}
-
-	return openControlData
-}
-
 var _ = Describe("Data", func() {
 	Describe("GetNarrative", func() {
 		It("returns the relevant singular narrative", func() {
-			data := loadOpenControlFixture()
+			data := fixtures.LoadOpenControlFixture()
 			result := data.GetNarrative("AC-2 (1)", "")
 			Expect(result).To(Equal("Amazon Elastic Compute Cloud\nJustification in narrative form for AC-2 (1)\n"))
 		})
 
 		It("returns the relevant narrative section", func() {
-			data := loadOpenControlFixture()
+			data := fixtures.LoadOpenControlFixture()
 			result := data.GetNarrative("AC-2", "a")
 			Expect(result).To(Equal("Amazon Elastic Compute Cloud\nJustification in narrative form A for AC-2\n"))
 		})

--- a/opencontrols/data_test.go
+++ b/opencontrols/data_test.go
@@ -1,0 +1,39 @@
+package opencontrols_test
+
+import (
+	"path/filepath"
+
+	. "github.com/opencontrol/fedramp-templater/opencontrols"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+// TODO share with templater_test
+func loadOpenControlFixture() Data {
+	openControlDir := filepath.Join("..", "fixtures", "opencontrols")
+	openControlDir, err := filepath.Abs(openControlDir)
+	Expect(err).NotTo(HaveOccurred())
+	openControlData, errors := LoadFrom(openControlDir)
+	for _, err := range errors {
+		Expect(err).NotTo(HaveOccurred())
+	}
+
+	return openControlData
+}
+
+var _ = Describe("Data", func() {
+	Describe("GetNarrative", func() {
+		It("returns the relevant singular narrative", func() {
+			data := loadOpenControlFixture()
+			result := data.GetNarrative("AC-2 (1)", "")
+			Expect(result).To(Equal("Amazon Elastic Compute Cloud\nJustification in narrative form for AC-2 (1)\n"))
+		})
+
+		It("returns the relevant narrative section", func() {
+			data := loadOpenControlFixture()
+			result := data.GetNarrative("AC-2", "a")
+			Expect(result).To(Equal("Amazon Elastic Compute Cloud\nJustification in narrative form A for AC-2\n"))
+		})
+	})
+})

--- a/opencontrols/opencontrols_suite_test.go
+++ b/opencontrols/opencontrols_suite_test.go
@@ -1,0 +1,13 @@
+package opencontrols_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestOpencontrols(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Opencontrols Suite")
+}

--- a/ssp/document.go
+++ b/ssp/document.go
@@ -1,6 +1,8 @@
 package ssp
 
 import (
+	"fmt"
+
 	"github.com/jbowtie/gokogiri/xml"
 	"github.com/opencontrol/doc-template/docx"
 	"github.com/opencontrol/fedramp-templater/docx/helper"
@@ -37,15 +39,33 @@ func Load(path string) (ssp *Document, err error) {
 }
 
 // SummaryTables returns the summary tables for the controls and the control enhancements.
-func (s *Document) SummaryTables() (tables []xml.Node, err error) {
+func (s *Document) SummaryTables() ([]xml.Node, error) {
 	// find the tables matching the provided headers, ignoring whitespace
 	return s.xmlDoc.Search(SummaryTablesXPath)
 }
 
-// NarrativeTables returns the narrative tables for the controls and the control enhancements.
-func (s *Document) NarrativeTables() (tables []xml.Node, err error) {
+// to retrieve all narrative tables, pass in an empty string
+func (s *Document) findNarrativeTables(control string) ([]xml.Node, error) {
 	// find the tables matching the provided headers, ignoring whitespace
-	return s.xmlDoc.Search("//w:tbl[contains(normalize-space(.), 'What is the solution and how is it implemented?')]")
+	xpath := fmt.Sprintf("//w:tbl[contains(normalize-space(.), '%s What is the solution and how is it implemented?')]", control)
+	return s.xmlDoc.Search(xpath)
+	// TODO return NarrativeTables
+}
+
+// NarrativeTables returns the narrative tables for the controls and the control enhancements.
+func (s *Document) NarrativeTables() ([]xml.Node, error) {
+	return s.findNarrativeTables("")
+}
+
+// NarrativeTables returns the narrative tables for the specified control or control enhancement.
+func (s *Document) NarrativeTable(control string) (table xml.Node, err error) {
+	tables, err := s.findNarrativeTables(control)
+	if err != nil {
+		return
+	}
+	// TODO return error if there is more than one
+	table = tables[0]
+	return
 }
 
 // Content retrieves the text from within the Word document.

--- a/ssp/document.go
+++ b/ssp/document.go
@@ -1,6 +1,7 @@
 package ssp
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/jbowtie/gokogiri/xml"
@@ -49,21 +50,26 @@ func (s *Document) findNarrativeTables(control string) ([]xml.Node, error) {
 	// find the tables matching the provided headers, ignoring whitespace
 	xpath := fmt.Sprintf("//w:tbl[contains(normalize-space(.), '%s What is the solution and how is it implemented?')]", control)
 	return s.xmlDoc.Search(xpath)
-	// TODO return NarrativeTables
 }
 
-// NarrativeTables returns the narrative tables for the controls and the control enhancements.
+// NarrativeTables returns the narrative tables for all controls and the control enhancements.
 func (s *Document) NarrativeTables() ([]xml.Node, error) {
 	return s.findNarrativeTables("")
 }
 
-// NarrativeTables returns the narrative tables for the specified control or control enhancement.
+// NarrativeTable returns the narrative table for the specified control or control enhancement.
 func (s *Document) NarrativeTable(control string) (table xml.Node, err error) {
 	tables, err := s.findNarrativeTables(control)
 	if err != nil {
 		return
 	}
-	// TODO return error if there is more than one
+	if len(tables) == 0 {
+		err = errors.New("No narrative tables found.")
+		return
+	} else if len(tables) > 1 {
+		err = errors.New("Too many narrative tables were matched.")
+		return
+	}
 	table = tables[0]
 	return
 }

--- a/ssp/document.go
+++ b/ssp/document.go
@@ -1,10 +1,9 @@
 package ssp
 
 import (
+	"github.com/jbowtie/gokogiri/xml"
 	"github.com/opencontrol/doc-template/docx"
 	"github.com/opencontrol/fedramp-templater/docx/helper"
-	// using fork because of https://github.com/moovweb/gokogiri/pull/93#issuecomment-215582446
-	"github.com/jbowtie/gokogiri/xml"
 )
 
 // SummaryTablesXPath is the pattern used to find summary tables within an SSP's XML.

--- a/ssp/document.go
+++ b/ssp/document.go
@@ -36,10 +36,16 @@ func Load(path string) (ssp *Document, err error) {
 	return
 }
 
-// SummaryTables returns the tables for the controls and the control enhancements.
+// SummaryTables returns the summary tables for the controls and the control enhancements.
 func (s *Document) SummaryTables() (tables []xml.Node, err error) {
 	// find the tables matching the provided headers, ignoring whitespace
 	return s.xmlDoc.Search(SummaryTablesXPath)
+}
+
+// NarrativeTables returns the narrative tables for the controls and the control enhancements.
+func (s *Document) NarrativeTables() (tables []xml.Node, err error) {
+	// find the tables matching the provided headers, ignoring whitespace
+	return s.xmlDoc.Search("//w:tbl[contains(normalize-space(.), 'What is the solution and how is it implemented?')]")
 }
 
 // Content retrieves the text from within the Word document.

--- a/ssp/document_test.go
+++ b/ssp/document_test.go
@@ -1,25 +1,17 @@
 package ssp_test
 
 import (
-	"path/filepath"
-
+	"github.com/opencontrol/fedramp-templater/fixtures"
 	. "github.com/opencontrol/fedramp-templater/ssp"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
-func loadSSP(name string) *Document {
-	path := filepath.Join("..", "fixtures", name)
-	doc, err := Load(path)
-	Expect(err).NotTo(HaveOccurred())
-	return doc
-}
-
 var _ = Describe("SSP", func() {
 	Describe("Load", func() {
 		It("gets the content from the doc", func() {
-			doc := loadSSP("FedRAMP_ac-2-1_v2.1.docx")
+			doc := fixtures.LoadSSP("FedRAMP_ac-2-1_v2.1.docx")
 			defer doc.Close()
 
 			Expect(doc.Content()).To(ContainSubstring("Control Enhancement"))
@@ -33,7 +25,7 @@ var _ = Describe("SSP", func() {
 
 	Describe("SummaryTables", func() {
 		It("returns the tables", func() {
-			doc := loadSSP("FedRAMP_ac-2_v2.1.docx")
+			doc := fixtures.LoadSSP("FedRAMP_ac-2_v2.1.docx")
 			defer doc.Close()
 
 			tables, err := doc.SummaryTables()

--- a/ssp/document_test.go
+++ b/ssp/document_test.go
@@ -37,7 +37,7 @@ var _ = Describe("SSP", func() {
 
 	Describe("NarrativeTables", func() {
 		It("returns the tables", func() {
-			doc := loadSSP("FedRAMP_ac-2_v2.1.docx")
+			doc := fixtures.LoadSSP("FedRAMP_ac-2_v2.1.docx")
 			defer doc.Close()
 
 			tables, err := doc.NarrativeTables()

--- a/ssp/document_test.go
+++ b/ssp/document_test.go
@@ -34,4 +34,16 @@ var _ = Describe("SSP", func() {
 			Expect(len(tables)).To(Equal(10))
 		})
 	})
+
+	Describe("NarrativeTables", func() {
+		It("returns the tables", func() {
+			doc := loadSSP("FedRAMP_ac-2_v2.1.docx")
+			defer doc.Close()
+
+			tables, err := doc.NarrativeTables()
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(tables)).To(Equal(8))
+		})
+	})
 })

--- a/templater/templater.go
+++ b/templater/templater.go
@@ -7,8 +7,7 @@ import (
 	"github.com/opencontrol/fedramp-templater/ssp"
 )
 
-// TemplatizeSSP inserts OpenControl data into (i.e. modifies) the provided SSP.
-func TemplatizeSSP(s *ssp.Document, openControlData opencontrols.Data) (err error) {
+func fillSummaryTables(s *ssp.Document, openControlData opencontrols.Data) (err error) {
 	tables, err := s.SummaryTables()
 	if err != nil {
 		return
@@ -17,10 +16,33 @@ func TemplatizeSSP(s *ssp.Document, openControlData opencontrols.Data) (err erro
 		st := control.NewSummaryTable(table)
 		err = st.Fill(openControlData)
 		if err != nil {
-			return err
+			return
 		}
 	}
 
+	return
+}
+
+func fillNarrativeTables(s *ssp.Document, openControlData opencontrols.Data) (err error) {
+	tables, err := s.NarrativeTables()
+	if err != nil {
+		return
+	}
+	for _, table := range tables {
+		ct := control.NewNarrativeTable(table)
+		err = ct.Fill(openControlData)
+		if err != nil {
+			return
+		}
+	}
+
+	return
+}
+
+// TemplatizeSSP inserts OpenControl data into (i.e. modifies) the provided SSP.
+func TemplatizeSSP(s *ssp.Document, openControlData opencontrols.Data) (err error) {
+	fillSummaryTables(s, openControlData)
+	fillNarrativeTables(s, openControlData)
 	s.UpdateContent()
 
 	return

--- a/templater/templater.go
+++ b/templater/templater.go
@@ -14,7 +14,7 @@ func TemplatizeSSP(s *ssp.Document, openControlData opencontrols.Data) (err erro
 		return
 	}
 	for _, table := range tables {
-		st := control.SummaryTable{Root: table}
+		st := control.NewSummaryTable(table)
 		err = st.Fill(openControlData)
 		if err != nil {
 			return err
@@ -34,7 +34,7 @@ func DiffSSP(s *ssp.Document, openControlData opencontrols.Data) ([]reporter.Rep
 		return diffInfo, err
 	}
 	for _, table := range tables {
-		st := control.SummaryTable{Root: table}
+		st := control.NewSummaryTable(table)
 		tableDiffInfo, err := st.Diff(openControlData)
 		if err != nil {
 			return diffInfo, err

--- a/templater/templater_test.go
+++ b/templater/templater_test.go
@@ -2,36 +2,14 @@ package templater_test
 
 import (
 	"bytes"
-	"path/filepath"
 
-	"github.com/opencontrol/fedramp-templater/opencontrols"
-	"github.com/opencontrol/fedramp-templater/ssp"
+	"github.com/opencontrol/fedramp-templater/fixtures"
 	. "github.com/opencontrol/fedramp-templater/templater"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/opencontrol/fedramp-templater/reporter"
 )
-
-func loadSSP(name string) *ssp.Document {
-	sspPath := filepath.Join("..", "fixtures", name)
-	doc, err := ssp.Load(sspPath)
-	Expect(err).NotTo(HaveOccurred())
-
-	return doc
-}
-
-func loadOpenControlFixture() opencontrols.Data {
-	openControlDir := filepath.Join("..", "fixtures", "opencontrols")
-	openControlDir, err := filepath.Abs(openControlDir)
-	Expect(err).NotTo(HaveOccurred())
-	openControlData, errors := opencontrols.LoadFrom(openControlDir)
-	for _, err := range errors {
-		Expect(err).NotTo(HaveOccurred())
-	}
-
-	return openControlData
-}
 
 func extractDiffReport(reporters []reporter.Reporter) string {
 	report := &bytes.Buffer{}
@@ -44,9 +22,9 @@ func extractDiffReport(reporters []reporter.Reporter) string {
 var _ = Describe("Templater", func() {
 	Describe("TemplatizeSSP", func() {
 		It("fills in the Responsible Role fields", func() {
-			doc := loadSSP("FedRAMP_ac-2-1_v2.1.docx")
+			doc := fixtures.LoadSSP("FedRAMP_ac-2-1_v2.1.docx")
 			defer doc.Close()
-			openControlData := loadOpenControlFixture()
+			openControlData := fixtures.LoadOpenControlFixture()
 
 			err := TemplatizeSSP(doc, openControlData)
 
@@ -62,14 +40,12 @@ var _ = Describe("Templater", func() {
 
 			By("Loading the SSP with the Responsible Role being 'OpenControl Role Placeholder' " +
 				"for Control 'AC-2 (1)'")
-			sspPath := filepath.Join("..", "fixtures", "FedRAMP_ac-2-1_v2.1.docx")
-			s, err := ssp.Load(sspPath)
-			Expect(err).NotTo(HaveOccurred())
+			s := fixtures.LoadSSP("FedRAMP_ac-2-1_v2.1.docx")
 			defer s.Close()
 
 			By("Loading the data from the opencontrol workspace with the Responsible Role being " +
 				"'Amazon Elastic Compute Cloud: AWS Staff' for Control 'AC-2 (1)'")
-			openControlData := loadOpenControlFixture()
+			openControlData := fixtures.LoadOpenControlFixture()
 
 			By("Calling 'diff' on the SSP")
 			diffInfo, err := DiffSSP(s, openControlData)

--- a/templater/templater_test.go
+++ b/templater/templater_test.go
@@ -32,6 +32,19 @@ var _ = Describe("Templater", func() {
 			content := doc.Content()
 			Expect(content).To(ContainSubstring(`Responsible Role: Amazon Elastic Compute Cloud: AWS Staff`))
 		})
+
+		It("fills in the narrative field", func() {
+			doc := fixtures.LoadSSP("FedRAMP_ac-2_v2.1.docx")
+			defer doc.Close()
+			openControlData := fixtures.LoadOpenControlFixture()
+
+			err := TemplatizeSSP(doc, openControlData)
+
+			Expect(err).NotTo(HaveOccurred())
+			content := doc.Content()
+			Expect(content).To(ContainSubstring(`Justification in narrative form B for AC-2`))
+			Expect(content).To(ContainSubstring(`Justification in narrative form for AC-2 (1)`))
+		})
 	})
 
 	Describe("DiffSSP", func() {

--- a/xml/helper/helper.go
+++ b/xml/helper/helper.go
@@ -1,0 +1,28 @@
+package helper
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/jbowtie/gokogiri/xml"
+)
+
+// SearchSubtree searches the subtree of the given root node.
+func SearchSubtree(root xml.Node, xpath string) (nodes []xml.Node, err error) {
+	// http://stackoverflow.com/a/25387687/358804
+	if !strings.HasPrefix(xpath, ".") {
+		err = errors.New("XPath must have leading period (`.`) to only search the subtree")
+		return
+	}
+
+	return root.Search(xpath)
+}
+
+// SearchSubtree searches the subtree of the given root node and returns the first result.
+func SearchOne(root xml.Node, xpath string) (xml.Node, error) {
+	results, err := SearchSubtree(root, xpath)
+	if err != nil {
+		return nil, err
+	}
+	return results[0], nil
+}


### PR DESCRIPTION
Centralizes logic that was a copied-and-pasted between various test files. Broken out from #29. Builds on #38.
