### PR TITLE
Improve error message

### DIFF
--- a/control/table.go
+++ b/control/table.go
@@ -41,7 +41,7 @@ func (t *table) controlName() (name string, err error) {
 	regex := regexp.MustCompile(`[A-Z]{2}-\d+( +\(\d+\))?`)
 	name = regex.FindString(content)
 	if name == "" {
-		err = errors.New("control name not found")
+		err = errors.New("control name not found for " + content)
 	}
 	return
 }


### PR DESCRIPTION
Previous error message looked like:
```
    .....
    Filling controls for  CM-2 (3)
    Problem occured while filling the Summary Table.
    control name not found
    2019/10/22 14:06:04 control name not found
```

Now, the error message gives a little more insight:
```
    .....
    Filling controls for  CM-2 (3)
    Problem occured while filling the Summary Table.
    control name not found for CM2 (7)Control Summary Information
    2019/10/22 14:08:22 control name not found for CM2 (7)Control Summary Information
```