### PR TITLE
Workaround typo in the 8/28/2018-version of FedRAMP-SSP-High-Baseline

### DIFF
--- a/control/table.go
+++ b/control/table.go
@@ -36,6 +36,10 @@ func (t *table) controlName() (name string, err error) {
 	if err != nil {
 		return
 	}
+	if content == "CM2 (7)Control Summary Information" {
+		// Workaround typo in the 8/28/2018 version of FedRAMP-SSP-High-Baseline-Template.docx
+		content = "CM-2 (7)Control Summary Information"
+	}
 
 	// matches controls and control enhancements, e.g. `AC-2`, `AC-2 (1)`, etc.
 	regex := regexp.MustCompile(`[A-Z]{2}-\d+( +\(\d+\))?`)


### PR DESCRIPTION
More details: In the document https://www.fedramp.gov/assets/resources/templates/FedRAMP-SSP-High-Baseline-Template.docx

On page 125, the heading of table reads:

    CM2 (7)     Control Summary Information

while it should read:

    CM-2 (7)     Control Summary Information

This typo has been already reported to info[at]FedRAMP.gov. In the meantime,
however I propose to carry this monkey patch within the templater tool.